### PR TITLE
Fix Firefox on Android border radius

### DIFF
--- a/webserver/web/src/css/style.scss
+++ b/webserver/web/src/css/style.scss
@@ -80,3 +80,7 @@ div.codesass.codesass--has-line-numbers::before {
 .diffs .subtitle.hunk code {
   background-color: darken($grey-darker, 5);
 }
+
+textarea.codesass__textarea {
+  border-radius: 0; 
+}


### PR DESCRIPTION
Fixes #74

![](https://i.imgur.com/oCEhlVN.png)

It is unclear why this works (or indeed where the radius came from in the first place...)