### PR TITLE
fix: don't show an empty table when the user has no api keys

### DIFF
--- a/webserver/web/templates/account/keys.html.tera
+++ b/webserver/web/templates/account/keys.html.tera
@@ -27,6 +27,7 @@ Manage API keys.
 {% endblock header_foot %}
 
 {% block main %}
+{% if keys | length != 0 %}
 <table class="table is-striped is-middle">
   <thead>
     <tr>
@@ -51,6 +52,10 @@ Manage API keys.
   </tr>
 {% endfor %}
 </table>
+{% else %}
+<em>You have no keys!</em>
+{% endif %}
+<hr/>
 <form action="/account/keys" method="post">
   <input type="hidden" name="anti_csrf_token" value="{{ session.data.anti_csrf_token }}"/>
   <div class="field has-addons">


### PR DESCRIPTION
before:
![before](https://i.imgur.com/83tRU8F.png)

after:
![before](https://i.imgur.com/j5h6af7.png)

The horizontal rule also appears when there is a table with this change.